### PR TITLE
Use a fork of zendesk_apps_support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     zendesk_apps_tools (3.8.1)
+      dxw-zendesk_apps_support (~> 4.29.5)
       execjs (~> 2.7.0)
       faraday (~> 0.9.2)
       faye-websocket (~> 0.11.0)
@@ -12,7 +13,6 @@ PATH
       sinatra-cross_origin (~> 0.3.1)
       thin (~> 1.7.2)
       thor (~> 0.19.4)
-      zendesk_apps_support (~> 4.29.5)
 
 GEM
   remote: https://rubygems.org/
@@ -75,6 +75,18 @@ GEM
       cucumber-messages (~> 13.0, >= 13.0.1)
     daemons (1.3.1)
     diff-lcs (1.4.4)
+    dxw-zendesk_apps_support (4.29.5)
+      erubis
+      i18n
+      image_size (~> 2.0.2)
+      ipaddress_2 (~> 0.13.0)
+      json
+      loofah (>= 2.2.3, < 2.10.0)
+      mimemagic (~> 0.3.3)
+      nokogiri (>= 1.8.5, < 1.12.0)
+      rb-inotify (= 0.9.10)
+      sass
+      sassc
     erubis (2.7.0)
     eventmachine (1.2.7)
     execjs (2.7.0)
@@ -95,25 +107,27 @@ GEM
       celluloid (~> 0.16.0)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
-    loofah (2.2.3)
+    loofah (2.9.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     middleware (0.1.0)
     mimemagic (0.3.5)
-    mini_portile2 (2.4.0)
+    mini_portile2 (2.5.0)
     minitest (5.14.3)
     multi_test (0.1.2)
     multipart-post (2.1.1)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
-    nokogiri (1.10.10)
-      mini_portile2 (~> 2.4.0)
+    nokogiri (1.11.1)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
     protobuf-cucumber (3.10.8)
       activesupport (>= 3.2)
       middleware
       thor
       thread_safe
     public_suffix (4.0.6)
+    racc (1.5.2)
     rack (2.2.3)
     rack-livereload (0.3.17)
       rack
@@ -137,7 +151,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.1)
-    ruby2_keywords (0.0.2)
+    ruby2_keywords (0.0.4)
     rubyzip (1.3.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
@@ -173,18 +187,6 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     zeitwerk (2.4.2)
-    zendesk_apps_support (4.29.6)
-      erubis
-      i18n
-      image_size (~> 2.0.2)
-      ipaddress_2 (~> 0.13.0)
-      json
-      loofah (~> 2.2.3)
-      mimemagic (~> 0.3.3)
-      nokogiri (>= 1.8.5, < 1.11.0)
-      rb-inotify (= 0.9.10)
-      sass
-      sassc
 
 PLATFORMS
   ruby

--- a/zendesk_apps_tools.gemspec
+++ b/zendesk_apps_tools.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'sinatra',     '~> 2.1.0'
   s.add_runtime_dependency 'faraday',     '~> 0.9.2'
   s.add_runtime_dependency 'execjs',      '~> 2.7.0'
-  s.add_runtime_dependency 'zendesk_apps_support', '~> 4.29.5'
+  s.add_runtime_dependency 'dxw-zendesk_apps_support', '~> 4.29.5'
   s.add_runtime_dependency 'sinatra-cross_origin', '~> 0.3.1'
   s.add_runtime_dependency 'listen', '~> 2.10'
   s.add_runtime_dependency 'rack-livereload'


### PR DESCRIPTION
One of the dependencies this gem relies on has some security alerts
(loofah and nokogiri), we have forked and published this dependency
while we wait for the main gem to be patched upstream.

This has a slight impact on dxw having to maintain updates from the
source repo. We should aim to retire our fork as soon as the changes
have been merged upstream.